### PR TITLE
fix: allow saving functionality on hero image media content.

### DIFF
--- a/client/src/app/genre/[type]/[id]/page.tsx
+++ b/client/src/app/genre/[type]/[id]/page.tsx
@@ -83,6 +83,7 @@ async function page({ params }: Props) {
     return (
         <div>
             <MobileHeroImageContainer
+                title={content.title}
                 id={content.id}
                 type={type as 'movie' | 'tv'}
                 posterPath={content.poster_path}

--- a/client/src/app/home/page.tsx
+++ b/client/src/app/home/page.tsx
@@ -18,6 +18,7 @@ const Home = async () => {
             <MobileHeroImageContainer
                 id={movieDetails.id}
                 type="movie"
+                title={movieDetails.title}
                 posterPath={movieDetails.poster_path}
                 backdropPath={movieDetails.backdrop_path}
                 savedContent={savedContent?.data}

--- a/client/src/app/movies/page.tsx
+++ b/client/src/app/movies/page.tsx
@@ -26,6 +26,7 @@ const Movies = async () => {
     return (
         <div className="flex flex-col">
             <MobileHeroImageContainer
+                title={happyGilmore2.title}
                 id={happyGilmore2.id}
                 type="movie"
                 posterPath={happyGilmore2.poster_path}

--- a/client/src/app/tv/page.tsx
+++ b/client/src/app/tv/page.tsx
@@ -19,6 +19,7 @@ const page = async () => {
     return (
         <div className="flex flex-col">
             <MobileHeroImageContainer
+                title={strangerThings.name}
                 id={strangerThings.id}
                 type="tv"
                 posterPath={strangerThings.poster_path}

--- a/client/src/components/ContentActionBtns.tsx
+++ b/client/src/components/ContentActionBtns.tsx
@@ -12,12 +12,13 @@ import { checkIfContentIsSaved } from '@/features/content/utils/CheckIfContentIs
 type Prop = {
     id: number;
     type: 'tv' | 'movie';
+    title: string;
     images: { posterPath: string; backdropPath: string };
     savedContent: SavedContent[] | undefined;
     children: ReactNode;
 };
 
-function ContentActionBtns({ id, type, savedContent, images, children }: Prop) {
+function ContentActionBtns({ id, type, title, savedContent, images, children }: Prop) {
     const { saveBtn, setSaveBtn, setSavedTitles } = useSaveContent();
     const accessToken = Cookies.get('auth_token') as string;
     useSetSavedContent({ setSaveBtn, contentId: String(id), savedContent, saveBtn });
@@ -41,6 +42,7 @@ function ContentActionBtns({ id, type, savedContent, images, children }: Prop) {
                         ? saveContent(
                               accessToken,
                               {
+                                  title,
                                   images,
                                   contentId: String(id),
                                   contentType: type,

--- a/client/src/features/home/containers/DesktopHeroImage.tsx
+++ b/client/src/features/home/containers/DesktopHeroImage.tsx
@@ -50,6 +50,7 @@ function DesktopHeroImage(props: Props) {
                     </p>
                     <div className="space-x-3 flex">
                         <ContentActionBtns
+                            title={title}
                             type={type}
                             id={id}
                             savedContent={savedContent}

--- a/client/src/features/home/containers/HeroImageContainer.tsx
+++ b/client/src/features/home/containers/HeroImageContainer.tsx
@@ -3,6 +3,7 @@ import MobileHeroImage from './MobileHeroImage';
 
 type Props = {
     id: number;
+    title: string;
     posterPath: string;
     backdropPath: string;
     type: 'tv' | 'movie';
@@ -11,6 +12,7 @@ type Props = {
 
 async function MobileHeroImageContainer({
     posterPath,
+    title,
     backdropPath,
     type,
     id,
@@ -29,6 +31,7 @@ async function MobileHeroImageContainer({
                 style={{ backgroundColor: bgColor }}
             />
             <MobileHeroImage
+                title={title}
                 type={type}
                 img={{ backdropPath, posterPath }}
                 id={id}

--- a/client/src/features/home/containers/MobileHeroImage.tsx
+++ b/client/src/features/home/containers/MobileHeroImage.tsx
@@ -5,13 +5,14 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import Image from 'next/image';
 
 type Props = {
+    title: string;
     img: contentImages;
     id: number;
     type: 'tv' | 'movie';
     savedContent: SavedContent[] | undefined;
 };
 
-function MobileHeroImage({ img, id, type, savedContent }: Props) {
+function MobileHeroImage({ img, title, id, type, savedContent }: Props) {
     const mobileScreenWidth = useMediaQuery(768); // We're seeking after a false value.
     return (
         <>
@@ -29,6 +30,7 @@ function MobileHeroImage({ img, id, type, savedContent }: Props) {
                     <div className="flex justify-center gap-4 w-full p-4 relative">
                         <div className="absolute z-[-1] inset-0 bg-[#000] h-[200%] translate-y-[-50%] mask-image-top rounded-lg" />
                         <ContentActionBtns
+                            title={title}
                             type={type}
                             id={id}
                             savedContent={savedContent}


### PR DESCRIPTION
Users could not save content displayed as a hero image, while other content saved correctly. This change updates the save logic to handle hero items as well. This problem appeared after I implemented the title property for saving media content. Fixes #105