### PR TITLE
fix: remove fixed height on media items

### DIFF
--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -12,7 +12,7 @@ async function page() {
     ]);
 
     return (
-        <div className="pt-8 space-y-8 md:space-y-20">
+        <div className="pt-8 pb-4 space-y-8 md:space-y-20">
             <UserInfo email={userInfo?.email} username={userInfo?.username} />
             <UserSavedTitles storedTitles={savedTitles?.data} />
         </div>

--- a/client/src/containers/ProfileContainer.tsx
+++ b/client/src/containers/ProfileContainer.tsx
@@ -24,7 +24,7 @@ function ProfileContainer({ username }: Props) {
                 height={icons.avatar.height}
                 className={`size-8 md:size-10 rounded-[2px]`}
             />
-            <p className={`hidden md:block h-4`}>{username || auth?.user?.username || 'User'}</p>
+            <p className={`hidden md:block`}>{username || auth?.user?.username || 'User'}</p>
         </div>
     );
 }

--- a/client/src/features/profile/components/UserSavedTitles.tsx
+++ b/client/src/features/profile/components/UserSavedTitles.tsx
@@ -40,24 +40,18 @@ function RenderSavedTitles({ titles }: { titles: SavedContent[] | undefined }) {
     if (!titles || titles.length === 0)
         return <p className="text-neutral-500 mx-6">No saved titles yet.</p>;
     return (
-        <ul className="card-grid-auto-fill">
-            {titles?.map((title, i) => {
+        <ul className="card-grid">
+            {titles?.map((title) => {
                 return (
-                    <li
-                        key={i}
-                        className="relative h-[210px] md:h-[323px] lg:h-[363px] 2xl:h-[480px] shadow-blackShadow"
-                    >
+                    <li key={title.content_id} className="relative shadow-blackShadow">
                         <Link href={`/content/${title.content_type}/${title.content_id}`}>
                             <Image
                                 src={`https://image.tmdb.org/t/p/w500/${title.poster_path}`}
                                 alt={title.content_type + ' content.'}
                                 width={342}
                                 height={513}
-                                className="h-full object-cover"
+                                className="size-full"
                             />
-                            <div className="absolute bottom-0 w-full bg-[#0000009c] text-sm md:text-base p-2 md:px-2 md:py-4 font-semibold">
-                                {title.title}
-                            </div>
                         </Link>
                     </li>
                 );


### PR DESCRIPTION
Having a fixed height for saved media content at different screen widths caused images to overflow within each item in the list.